### PR TITLE
Extract filename and content type into Refile::Uploadable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
+Style/GuardClause:
+  Enabled: false
+
 Style/AndOr:
   Enabled: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,9 @@ end
 
 RSpec::Core::RakeTask.new(:spec)
 
-RuboCop::RakeTask.new
+RuboCop::RakeTask.new do |task|
+  task.options = ["--display-cop-names"]
+end
 
 task default: [:spec, :rubocop]
 

--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -2,7 +2,6 @@ require "uri"
 require "fileutils"
 require "tempfile"
 require "logger"
-require "mime/types"
 
 module Refile
   # @api private
@@ -176,46 +175,11 @@ module Refile
     # @raise [Refile::Invalid]  If the uploadable's size is too large
     # @return [true]            Always returns true if it doesn't raise
     def verify_uploadable(uploadable, max_size)
-      [:size, :read, :eof?, :close].each do |m|
-        unless uploadable.respond_to?(m)
-          raise ArgumentError, "does not respond to `#{m}`."
-        end
-      end
+      Refile::Uploadable.validate!(uploadable)
       if max_size and uploadable.size > max_size
         raise Refile::Invalid, "#{uploadable.inspect} is too large"
       end
       true
-    end
-
-    # Extract the filename from an uploadable object. If the filename cannot be
-    # determined, this method will return `nil`.
-    #
-    # @param [IO] uploadable    The uploadable object to extract the filename from
-    # @return [String, nil]     The extracted filename
-    def extract_filename(uploadable)
-      path = if uploadable.respond_to?(:original_filename)
-        uploadable.original_filename
-      elsif uploadable.respond_to?(:path)
-        uploadable.path
-      end
-      ::File.basename(path) if path
-    end
-
-    # Extract the content type from an uploadable object. If the content type
-    # cannot be determined, this method will return `nil`.
-    #
-    # @param [IO] uploadable    The uploadable object to extract the content type from
-    # @return [String, nil]     The extracted content type
-    def extract_content_type(uploadable)
-      if uploadable.respond_to?(:content_type)
-        uploadable.content_type
-      else
-        filename = extract_filename(uploadable)
-        if filename
-          content_type = MIME::Types.of(filename).first
-          content_type.to_s if content_type
-        end
-      end
     end
 
     # Generate a URL to an attachment. This method receives an instance of a
@@ -273,6 +237,7 @@ module Refile
   require "refile/attacher"
   require "refile/attachment"
   require "refile/random_hasher"
+  require "refile/uploadable"
   require "refile/file"
   require "refile/custom_logger"
   require "refile/app"

--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -82,10 +82,12 @@ module Refile
     end
 
     def cache!(uploadable)
+      uploadable = Refile::Uploadable.new(uploadable)
+
       @metadata = {
         size: uploadable.size,
-        content_type: Refile.extract_content_type(uploadable),
-        filename: Refile.extract_filename(uploadable)
+        content_type: uploadable.content_type,
+        filename: uploadable.filename
       }
       if valid?
         @metadata[:id] = cache.upload(uploadable).id

--- a/lib/refile/uploadable.rb
+++ b/lib/refile/uploadable.rb
@@ -1,0 +1,54 @@
+require "forwardable"
+require "mime/types"
+
+module Refile
+  class Uploadable
+    extend Forwardable
+
+    IO_METHODS = [:size, :read, :eof?, :close]
+
+    def self.validate!(io)
+      IO_METHODS.each do |m|
+        unless io.respond_to?(m)
+          raise ArgumentError, "does not respond to `#{m}`."
+        end
+      end
+    end
+
+    # @param io [#read, #eof?, #close, #size]
+    #
+    # @api private
+    def initialize(io)
+      self.class.validate!(io)
+      @io = io
+    end
+
+    delegate IO_METHODS => :io
+
+    # Extracts the filename from the underlying IO. If the filename cannot be
+    # determined, this method will return `nil`.
+    #
+    # @return [String, nil]     The extracted filename
+    def filename
+      return io.original_filename     if io.respond_to?(:original_filename)
+      return ::File.basename(io.path) if io.respond_to?(:path)
+    end
+
+    # Extracts the content type from underlying IO. If the content type cannot
+    # be determined, this method will return `nil`.
+    #
+    # @return [String, nil]     The extracted content type
+    def content_type
+      return io.content_type if io.respond_to?(:content_type)
+
+      if filename
+        content_type = MIME::Types.of(filename).first
+        content_type.to_s if content_type
+      end
+    end
+
+  private
+
+    attr_reader :io
+  end
+end

--- a/spec/refile/uploadable_spec.rb
+++ b/spec/refile/uploadable_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe Refile::Uploadable do
+  let(:io) { double(size: 444, read: nil, eof?: true, close: nil) }
+
+  describe "#initialize" do
+    it "works if argument conforms to required API" do
+      Refile::Uploadable.new(double(size: 444, read: nil, eof?: true, close: nil))
+    end
+
+    it "raises ArgumentError if argument does not respond to `size`" do
+      expect { Refile::Uploadable.new(double(read: nil, eof?: true, close: nil)) }
+        .to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError if argument does not respond to `read`" do
+      expect { Refile::Uploadable.new(double(size: 444, eof?: true, close: nil)) }
+        .to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError if argument does not respond to `eof?`" do
+      expect { Refile::Uploadable.new(double(size: 444, read: true, close: nil)) }
+        .to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError if argument does not respond to `close`" do
+      expect { Refile::Uploadable.new(double(size: 444, read: true, eof?: true)) }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#filename" do
+    it "extracts filename from original_filename" do
+      allow(io).to receive(:original_filename).and_return("baz.png")
+      file = Refile::Uploadable.new(io)
+      expect(file.filename).to eq("baz.png")
+    end
+
+    it "extracts filename from path" do
+      allow(io).to receive(:path).and_return("/foo/bar/baz.png")
+      file = Refile::Uploadable.new(io)
+      expect(file.filename).to eq("baz.png")
+    end
+
+    it "returns nil if it can't determine filename" do
+      file = Refile::Uploadable.new(io)
+      expect(file.filename).to be_nil
+    end
+  end
+
+  describe "#content_type" do
+    it "extracts content type" do
+      allow(io).to receive(:content_type).and_return("image/jpeg")
+      file = Refile::Uploadable.new(io)
+      expect(file.content_type).to eq("image/jpeg")
+    end
+
+    it "extracts content type from extension" do
+      allow(io).to receive(:path).and_return("test.png")
+      file = Refile::Uploadable.new(io)
+      expect(file.content_type).to eq("image/png")
+    end
+
+    it "returns nil if it can't determine content type" do
+      file = Refile::Uploadable.new(io)
+      expect(file.content_type).to be_nil
+    end
+
+    it "returns nil if it has an unknown content type" do
+      allow(io).to receive(:path).and_return("foo.blah")
+      file = Refile::Uploadable.new(io)
+      expect(file.content_type).to be_nil
+    end
+  end
+end

--- a/spec/refile_spec.rb
+++ b/spec/refile_spec.rb
@@ -4,71 +4,12 @@ RSpec.describe Refile do
   let(:io) { StringIO.new("hello") }
 
   describe ".verify_uploadable" do
-    it "works if it conforms to required API" do
-      expect(Refile.verify_uploadable(double(size: 444, read: io, eof?: true, close: nil), nil)).to be_truthy
-    end
-
-    it "raises ArgumentError if argument does not respond to `size`" do
-      expect { Refile.verify_uploadable(double(read: io, eof?: true, close: nil), nil) }.to raise_error(ArgumentError)
-    end
-
-    it "raises ArgumentError if argument does not respond to `read`" do
-      expect { Refile.verify_uploadable(double(size: 444, eof?: true, close: nil), nil) }.to raise_error(ArgumentError)
-    end
-
-    it "raises ArgumentError if argument does not respond to `eof?`" do
-      expect { Refile.verify_uploadable(double(size: 444, read: true, close: nil), nil) }.to raise_error(ArgumentError)
-    end
-
-    it "raises ArgumentError if argument does not respond to `close`" do
-      expect { Refile.verify_uploadable(double(size: 444, read: true, eof?: true), nil) }.to raise_error(ArgumentError)
-    end
-
     it "returns true if size is respeced" do
       expect(Refile.verify_uploadable(Refile::FileDouble.new("hello"), 8)).to be_truthy
     end
 
     it "raises Refile::Invalid if size is exceeded" do
       expect { Refile.verify_uploadable(Refile::FileDouble.new("hello world"), 8) }.to raise_error(Refile::Invalid)
-    end
-  end
-
-  describe ".extract_filename" do
-    it "extracts filename from original_filename" do
-      name = Refile.extract_filename(double(original_filename: "/foo/bar/baz.png"))
-      expect(name).to eq("baz.png")
-    end
-
-    it "extracts filename from path" do
-      name = Refile.extract_filename(double(path: "/foo/bar/baz.png"))
-      expect(name).to eq("baz.png")
-    end
-
-    it "returns nil if it can't determine filename" do
-      name = Refile.extract_filename(double)
-      expect(name).to be_nil
-    end
-  end
-
-  describe ".extract_content_type" do
-    it "extracts content type" do
-      name = Refile.extract_content_type(double(content_type: "image/jpeg"))
-      expect(name).to eq("image/jpeg")
-    end
-
-    it "extracts content type from extension" do
-      name = Refile.extract_content_type(double(original_filename: "test.png"))
-      expect(name).to eq("image/png")
-    end
-
-    it "returns nil if it can't determine content type" do
-      name = Refile.extract_filename(double)
-      expect(name).to be_nil
-    end
-
-    it "returns nil if it has an unknown content type" do
-      name = Refile.extract_content_type(double(original_filename: "foo.blah"))
-      expect(name).to be_nil
     end
   end
 


### PR DESCRIPTION
Instead of extracting filename and content_type through the Refile constant, it feels much better to take an object oriented approach. Refile::File now wraps the uploadable from the outside world, and doesn't know anything about backends or IDs.

What I originally intended with this is that we can now, instead of handling content types and extensions in `Refile::Attacher`, just let users register their validators (and pass them though `:type` parameter), which would yield a `Refile::File` and then users can write their own validation (the same way that they register processors). Of course, Refile would still provide an `:image` validator. This way `Refile::File` would abstract the "uploadable".

I realized only before opening this PR that I broke the `#copy_to` in the S3 backend. Do you think this approach has potential to justify trying to fix the S3 in another way? And also justify `Refile::Backend#upload` now returning an ID instead of a `Refile::File`? Probably not :P