### PR TITLE
Cache gem dependencies on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
 gemfile:
   - Gemfile
 
+cache: bundler
+
 sudo: false
 
 before_script:


### PR DESCRIPTION
With their new infrastructure also came this ability for open source projects, and bundling itself takes more than 1 minute.