### PR TITLE
Use block form of logger.info

### DIFF
--- a/lib/refile/custom_logger.rb
+++ b/lib/refile/custom_logger.rb
@@ -18,16 +18,18 @@ module Refile
 
     def log(env, status, began_at)
       now = Time.now
-      logger.info format(
-        LOG_FORMAT,
-        @prefix,
-        now.strftime("%F %T %z"),
-        env["REQUEST_METHOD"],
-        env["PATH_INFO"],
-        env["QUERY_STRING"].empty? ? "" : "?" + env["QUERY_STRING"],
-        status.to_s[0..3],
-        (now - began_at) * 1000
-      )
+      logger.info do
+        format(
+          LOG_FORMAT,
+          @prefix,
+          now.strftime("%F %T %z"),
+          env["REQUEST_METHOD"],
+          env["PATH_INFO"],
+          env["QUERY_STRING"].empty? ? "" : "?" + env["QUERY_STRING"],
+          status.to_s[0..3],
+          (now - began_at) * 1000
+        )
+      end
     end
 
     def logger

--- a/spec/refile/custom_logger_spec.rb
+++ b/spec/refile/custom_logger_spec.rb
@@ -1,0 +1,22 @@
+require "active_support/logger"
+require "refile/custom_logger"
+
+describe Refile::CustomLogger do
+  let(:rack_app) do
+    ->(_) { [200, {}, ["Success"]] }
+  end
+  let(:io) { StringIO.new }
+  let(:env) do
+    { "QUERY_STRING" => "",
+      "REQUEST_METHOD" => "POST",
+      "PATH_INFO" => "/" }
+  end
+
+  let(:expected_format) { /^Prefix: \[[^\]]+\] POST "\/" 200 \d+\.\d+ms\n\n$/ }
+
+  it "uses a dynamic logger" do
+    _, _, body = described_class.new(rack_app, "Prefix", -> { ActiveSupport::Logger.new(io) }).call(env)
+    body.close
+    expect(io.tap(&:rewind).read).to match(expected_format)
+  end
+end


### PR DESCRIPTION
This defers execution. In the case that the log level is set to
something higher than INFO, it will not execute the block.

Also, add a formatting spec for the logger.