### PR TITLE
Add disposition option to attachment_url for forcing file downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,12 @@ no file has been uploaded:
 <%= attachment_image_tag(@user, :profile_image, :fill, 300, 300, fallback: "default.png") %>
 ```
 
+You can also force downloading of a file instead of rendering inline:
+
+``` erb
+<%= attachment_image_tag(@user, :cv, disposition: :attachment) %>
+```
+
 ## 5. JavaScript library
 
 Refile's JavaScript library is small but powerful.

--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -248,7 +248,7 @@ module Refile
     # @param [String, nil] host            Override the host
     # @param [String, nil] prefix          Adds a prefix to the URL if the application is not mounted at root
     # @return [String, nil]                The generated URL
-    def attachment_url(object, name, *args, prefix: nil, filename: nil, format: nil, host: nil)
+    def attachment_url(object, name, *args, prefix: nil, filename: nil, format: nil, host: nil, disposition: nil)
       attacher = object.send(:"#{name}_attacher")
       file = attacher.get
       return unless file
@@ -265,6 +265,7 @@ module Refile
 
       uri = URI(host.to_s)
       uri.path = ::File.join("", *prefix, backend_name, *args.map(&:to_s), file.id.to_s, filename)
+      uri.query = "disposition=#{disposition}" if disposition
       uri.to_s
     end
   end

--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -95,8 +95,9 @@ module Refile
       end
 
       filename = request.path.split("/").last
+      disposition = params[:disposition] || "inline"
 
-      send_file path, filename: filename, disposition: "inline", type: ::File.extname(request.path)
+      send_file path, filename: filename, disposition: disposition, type: ::File.extname(request.path)
     end
 
     def backend


### PR DESCRIPTION
Add option for requesting a file with the `disposition: "attachment"`.

This fixes #118