### PR TITLE
Extract backend methods

### DIFF
--- a/lib/refile/backend_macros.rb
+++ b/lib/refile/backend_macros.rb
@@ -7,7 +7,7 @@ module Refile
       mod = Module.new do
         define_method(method) do |id|
           id = id.to_s
-          if id =~ /\A[a-z0-9]+\z/i
+          if self.class.valid_id?(id)
             super(id)
           else
             raise Refile::InvalidID
@@ -32,6 +32,10 @@ module Refile
         end
       end
       prepend mod
+    end
+
+    def valid_id?(id)
+      id =~ /\A[a-z0-9]+\z/i
     end
   end
 end

--- a/lib/refile/backend_macros.rb
+++ b/lib/refile/backend_macros.rb
@@ -6,7 +6,7 @@ module Refile
     def verify_id(method)
       mod = Module.new do
         define_method(method) do |id|
-          id = id.to_s
+          id = self.class.decode_id(id)
           if self.class.valid_id?(id)
             super(id)
           else
@@ -36,6 +36,10 @@ module Refile
 
     def valid_id?(id)
       id =~ /\A[a-z0-9]+\z/i
+    end
+
+    def decode_id(id)
+      id.to_s
     end
   end
 end

--- a/spec/refile/backend_macros_spec.rb
+++ b/spec/refile/backend_macros_spec.rb
@@ -59,4 +59,14 @@ RSpec.describe Refile::BackendMacros do
       expect { instance.get("ev/il") }.to raise_error(Refile::InvalidID)
     end
   end
+
+  describe "#valid_id?" do
+    it "returns true for valid ID" do
+      expect(klass.valid_id?("1234aBCde123aee")).to be_truthy
+    end
+
+    it "returns false for invalid ID" do
+      expect(klass.valid_id?("ev/il")).to be_falsey
+    end
+  end
 end

--- a/spec/refile/backend_macros_spec.rb
+++ b/spec/refile/backend_macros_spec.rb
@@ -69,4 +69,11 @@ RSpec.describe Refile::BackendMacros do
       expect(klass.valid_id?("ev/il")).to be_falsey
     end
   end
+
+  describe "#decode_id" do
+    it "returns to_s" do
+      expect(klass.decode_id("1234aBCde123aee")).to eq "1234aBCde123aee"
+      expect(klass.decode_id(1234)).to eq "1234"
+    end
+  end
 end


### PR DESCRIPTION
Consider this use case for Refile:

App using Refile also supports UGC markdown with images. Markdown preprocessor in app rewrites image srcs to Refile attachment URLs to a "remote url" to leverage processing, CDN and prevent mixed content warning for non-ssl images. 

Image srcs are `Base64` encoded in attachment urls to resolve to a proper route in `Refile::App`; they must be decoded by the backend for remote retrieval.

Example:
```markdown
![lolcat](http://example.com/lolcat.gif)

![lolcat](//refile-cdn.com/remote/aHR0cDovL2V4YW1wbGUuY29tL2xvbGNhdC5naWY=/processed.gif)
```

To support this, I've extracted a few methods that allow backends to customize the default behavior of the `verify_id` macro. These changes would allow our example remote url backend to decode the id and supply its own matcher to verify the id.
